### PR TITLE
MacOS support for ReaperCo

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,6 +6,12 @@
   <component name="ChangeListManager">
     <list default="true" id="e9a71cce-d857-4619-a4d4-1e84aa6bc4a5" name="Changes" comment="Fixed windows bug that added the secret desktop.ini config to the modpacks">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/README.md" beforeDir="false" afterPath="$PROJECT_DIR$/README.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/constants.py" beforeDir="false" afterPath="$PROJECT_DIR$/constants.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/filemanagerutils.py" beforeDir="false" afterPath="$PROJECT_DIR$/filemanagerutils.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/mainwindowfunc.py" beforeDir="false" afterPath="$PROJECT_DIR$/mainwindowfunc.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/mainwindowui.py" beforeDir="false" afterPath="$PROJECT_DIR$/mainwindowui.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/windowUIFiles/mainwindow.ui" beforeDir="false" afterPath="$PROJECT_DIR$/windowUIFiles/mainwindow.ui" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -20,15 +26,35 @@
     </option>
   </component>
   <component name="Git.Settings">
+    <option name="RECENT_BRANCH_BY_REPOSITORY">
+      <map>
+        <entry key="$PROJECT_DIR$" value="master" />
+      </map>
+    </option>
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
     <option name="RESET_MODE" value="MIXED" />
   </component>
-  <component name="GitHubPullRequestSearchHistory">{
-  &quot;lastFilter&quot;: {
-    &quot;state&quot;: &quot;OPEN&quot;,
-    &quot;assignee&quot;: &quot;KidWizardOfTheWeb&quot;
+  <component name="GitHubPullRequestSearchHistory"><![CDATA[{
+  "history": [
+    {
+      "state": "OPEN"
+    }
+  ],
+  "lastFilter": {
+    "state": "OPEN"
   }
-}</component>
+}]]></component>
+  <component name="GitHubPullRequestState"><![CDATA[{
+  "prStates": [
+    {
+      "id": {
+        "id": "PR_kwDOQB4sNs6yUEgM",
+        "number": 1
+      },
+      "lastSeen": 1762635794059
+    }
+  ]
+}]]></component>
   <component name="GithubPullRequestsUISettings">{
   &quot;selectedUrlAndAccountId&quot;: {
     &quot;url&quot;: &quot;https://github.com/KidWizardOfTheWeb/ReaperCo.ModManager&quot;,
@@ -58,7 +84,7 @@
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "master",
+    "git-widget-placeholder": "#1 on fork/NullPTrException1/macos__dev",
     "ignore.virus.scanning.warn.message": "true",
     "settings.editor.selected.configurable": "reference.idesettings.debugger.python"
   }
@@ -262,7 +288,19 @@
       <map>
         <entry key="MAIN">
           <value>
-            <State />
+            <State>
+              <option name="FILTERS">
+                <map>
+                  <entry key="branch">
+                    <value>
+                      <list>
+                        <option value="fork/NullPTrException1/macos_dev" />
+                      </list>
+                    </value>
+                  </entry>
+                </map>
+              </option>
+            </State>
           </value>
         </entry>
       </map>
@@ -295,13 +333,8 @@
           <option name="timeStamp" value="1" />
         </line-breakpoint>
         <line-breakpoint enabled="true" suspend="THREAD" type="python-line">
-          <url>file://$PROJECT_DIR$/mainwindowui.py</url>
-          <line>289</line>
-          <option name="timeStamp" value="55" />
-        </line-breakpoint>
-        <line-breakpoint enabled="true" suspend="THREAD" type="python-line">
           <url>file://$PROJECT_DIR$/mainwindowfunc.py</url>
-          <line>228</line>
+          <line>289</line>
           <option name="timeStamp" value="66" />
         </line-breakpoint>
         <line-breakpoint enabled="true" suspend="THREAD" type="python-line">
@@ -316,7 +349,7 @@
         </line-breakpoint>
         <line-breakpoint enabled="true" suspend="THREAD" type="python-line">
           <url>file://$PROJECT_DIR$/mainwindowfunc.py</url>
-          <line>463</line>
+          <line>526</line>
           <option name="timeStamp" value="100" />
         </line-breakpoint>
         <line-breakpoint enabled="true" suspend="THREAD" type="python-line">
@@ -326,7 +359,7 @@
         </line-breakpoint>
         <line-breakpoint enabled="true" suspend="THREAD" type="python-line">
           <url>file://$PROJECT_DIR$/mainwindowui.py</url>
-          <line>130</line>
+          <line>134</line>
           <option name="timeStamp" value="110" />
         </line-breakpoint>
         <line-breakpoint enabled="true" suspend="THREAD" type="python-line">

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ py main.py
 4. In the settings tab, use the triple dot buttons to set your directories to the following:
 - **Mods Directory** - Set to the folder created in step 2.
 - **Dolphin Directory** - Set to the root of your Dolphin build (the folder where `dolphin.exe`/`dolphintool.exe` exists).
-- **Textures Directory** - WIP, non-functional for now. You can set this to your `User/Load/Textures` path in Dolphin for now if you want.
+- **Modules Directory** - WIP, non-functional for now. In the future, we will support external scripts being connected to RCMM for any purpose.
 
 <img width="789" height="363" alt="image" src="https://github.com/user-attachments/assets/a5e4dccf-2d26-43f1-8ff9-5138f19a3c46" />
 <br></br>
@@ -103,7 +103,7 @@ Turning mods on/off is as simple as choosing your game, clicking the checkboxes,
 <img width="592" height="666" alt="image" src="https://github.com/user-attachments/assets/d8187872-0b0d-4c82-92b6-bd372e3e1e46" />
 <br></br>
 
-3. Press the save button. If you have two or mods selected, this will open up a menu that will allow you to reorder your mods in terms of priority with drag/drop.
+3. Press the save button. If you have two or more selected, this will open up a menu that will allow you to reorder your mods in terms of priority with drag/drop.
 
 **You can skip this step by pressing "OK" if none of your mods have conflicting files, as this is for power users/mod priority fixes.** 
 

--- a/constants.py
+++ b/constants.py
@@ -1,11 +1,20 @@
 from pathlib import Path
+from sys import platform
 UI_FOLDER_PATH = Path("windowUIFiles")
 
 # Some programmers hate magic strings. While this seemed weird to me at first to write this as a constant,
 # I think it'll just be easier to have this available as an autofill tbh.
 # TODO: Make linux/mac versions of these. .EXE is a mainly windows thing (as I am a windows user rn, sorry for my sins).
-DOLPHIN_EXE = "dolphin.exe"
-DOLPHIN_TOOL = "dolphintool.exe"
+
+if platform == "win32": #Windows
+    DOLPHIN_EXE = "dolphin.exe"
+    DOLPHIN_TOOL = "dolphintool.exe"
+elif platform == "darwin": #MacOS
+    DOLPHIN_EXE = "Dolphin.app"
+    DOLPHIN_TOOL = "dolphin-tool"
+elif platform == "linux": #Linux
+    DOLPHIN_EXE = "" #uhhh idk how to handle the flatpak values yet.
+    DOLPHIN_TOOL = ""
 SETTINGS_INI = "settings.ini"
 MODSDB_INI = "modsDB.ini"
 DB_INI = "db.ini"

--- a/constants.py
+++ b/constants.py
@@ -22,3 +22,6 @@ DB_INI = "db.ini"
 ORIGINAL_ISO_DIR = "{}_ISO"
 MOD_ISO_DIR = "{}_MOD"
 MOD_PACK_DIR = "{}_Mods"
+
+# Support for extra script plugins coming later
+PLUGINS_DIR = "{}_Plugins"

--- a/constants.py
+++ b/constants.py
@@ -10,7 +10,7 @@ if platform == "win32": #Windows
     DOLPHIN_EXE = "dolphin.exe"
     DOLPHIN_TOOL = "dolphintool.exe"
 elif platform == "darwin": #MacOS
-    DOLPHIN_EXE = "Dolphin.app"
+    DOLPHIN_EXE = "Dolphin.app/Contents/MacOS/Dolphin"
     DOLPHIN_TOOL = "dolphin-tool"
 elif platform == "linux": #Linux
     DOLPHIN_EXE = "" #uhhh idk how to handle the flatpak values yet.

--- a/constants.py
+++ b/constants.py
@@ -13,12 +13,12 @@ elif platform == "darwin": #MacOS
     DOLPHIN_EXE = "Dolphin.app/Contents/MacOS/Dolphin"
     DOLPHIN_TOOL = "dolphin-tool"
 elif platform == "linux": #Linux
-    DOLPHIN_EXE = "" #uhhh idk how to handle the flatpak values yet.
-    DOLPHIN_TOOL = ""
+    DOLPHIN_EXE = "org.DolphinEmu.dolphin-emu"
+    DOLPHIN_TOOL = "--command=dolphin-tool"
 SETTINGS_INI = "settings.ini"
 MODSDB_INI = "modsDB.ini"
 DB_INI = "db.ini"
 
 ORIGINAL_ISO_DIR = "{}_ISO"
 MOD_ISO_DIR = "{}_MOD"
-MOD_PACK_DIR = "{}_mods"
+MOD_PACK_DIR = "{}_Mods"

--- a/filemanagerutils.py
+++ b/filemanagerutils.py
@@ -11,7 +11,7 @@ def generate_settings_ini(settings_ini):
     if sys.platform == "linux":
         config_data['LauncherLoader'] = {
             "ISODir": "",
-            "TexturesDir": "",
+            "PluginsDir": "",
             "ModsDir": "",
             "DolphinDir": "Do Not Set This",
             "SaveAndPlayBehavior": "0"
@@ -19,7 +19,7 @@ def generate_settings_ini(settings_ini):
     else:
         config_data['LauncherLoader'] = {
             "ISODir": "",
-            "TexturesDir": "",
+            "PluginsDir": "",
             "ModsDir": "",
             "DolphinDir": "",
             "SaveAndPlayBehavior": "0"

--- a/filemanagerutils.py
+++ b/filemanagerutils.py
@@ -8,13 +8,22 @@ def generate_settings_ini(settings_ini):
     # https://stackoverflow.com/questions/8884188/how-to-read-and-write-ini-file-with-python3
     config_data = configparser.ConfigParser()
 
-    config_data['LauncherLoader'] = {
-        "ISODir": "",
-        "TexturesDir": "",
-        "ModsDir": "",
-        "DolphinDir": "",
-        "SaveAndPlayBehavior": "0"
-    }
+    if sys.platform == "linux":
+        config_data['LauncherLoader'] = {
+            "ISODir": "",
+            "TexturesDir": "",
+            "ModsDir": "",
+            "DolphinDir": "Do Not Set This",
+            "SaveAndPlayBehavior": "0"
+        }
+    else:
+        config_data['LauncherLoader'] = {
+            "ISODir": "",
+            "TexturesDir": "",
+            "ModsDir": "",
+            "DolphinDir": "",
+            "SaveAndPlayBehavior": "0"
+        }
 
     config_data['AppSettings'] = {
         "autoUpdateCheckerLauncher": "1",

--- a/mainwindowfunc.py
+++ b/mainwindowfunc.py
@@ -455,16 +455,17 @@ def start_dolphin_game(game_title):
 
     params = []
     if play_behavior == 0:
-        params = [path_to_dolphin_exe, "-e", path_to_game_dol]
+        params = [path_to_dolphin_exe, "-e", f"{path_to_game_dol}"]
     elif play_behavior == 1:
-        params = [path_to_dolphin_exe, "-e", path_to_game_dol, "-b"]
+        params = [path_to_dolphin_exe, "-e", f"{path_to_game_dol}", "-b"]
 
+    print(params)
     try:
         if sys.platform == "win32":
             dolphin_proc = subprocess.Popen(params,
                                 creationflags=subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP)
         else:
-            dolphin_proc = subprocess.Popen(params, shell=True)
+            dolphin_proc = subprocess.Popen(params)
         return
     except subprocess.CalledProcessError as e:
         print(f"Command failed with return code {e.returncode}")

--- a/mainwindowfunc.py
+++ b/mainwindowfunc.py
@@ -162,9 +162,14 @@ def add_new_game_from_dolphin():
     return gameID, gameTitle
 
 def set_up_directory(directory_option):
-    tkinter.Tk().withdraw()  # prevents an empty tkinter window from appearing
+    print("I think tk withdraw is failing. Check it.")
+    root = tkinter.Tk()
+    root.withdraw() # Prevents an empty tkinter window from appearing
+    # tkinter.Tk().withdraw()  # prevents an empty tkinter window from appearing
     # Return file selected
+    print("Are we at askdirectory?")
     path_to_directory = filedialog.askdirectory()
+    print("Are we past askdirectory?")
     set_config_option(SETTINGS_INI,
                       path_to_config=os.path.join(os.getcwd(), "config"),
                       section_to_write="LauncherLoader",

--- a/mainwindowfunc.py
+++ b/mainwindowfunc.py
@@ -24,7 +24,7 @@ def check_paths():
                                        "LauncherLoader",
                                        "modsdir")
 
-    if not path_to_dolphin and not path_to_mods:
+    if not path_to_dolphin or not path_to_mods:
         # Error window here, print what's missing, end function
         print("Error here! Path to dolphin or path to mods missing.")
         return None, None
@@ -102,7 +102,7 @@ def add_new_game_from_dolphin(path_to_new_game):
     #                                    "LauncherLoader",
     #                                    "modsdir")
 
-    if not path_to_dolphin and not path_to_mods:
+    if not path_to_dolphin or not path_to_mods:
     #     # Error window here, print what's missing, end function
     #     print("Error here! Path to dolphin or path to mods missing.")
         return
@@ -420,7 +420,7 @@ def get_enabled_mods(game_title, mod_title, return_titles=False):
 def start_dolphin_game(game_title):
     path_to_dolphin, path_to_mods = check_paths()
 
-    if not path_to_dolphin and not path_to_mods:
+    if not path_to_dolphin or not path_to_mods:
         # Error window here, print what's missing, end function
         # print("Error here! Path to dolphin or path to mods missing.")
         return

--- a/mainwindowui.py
+++ b/mainwindowui.py
@@ -300,7 +300,12 @@ class MainWindow(QMainWindow):
         selected_item = self.currentGameCombobox.currentText()
         if selected_item == "Add new game here":
             path_to_new_game = QFileDialog.getOpenFileName(self, caption="Select Game", filter="Games (*.iso)")
-            gameID, gameTitle = add_new_game_from_dolphin(path_to_new_game[0])
+            try:
+                gameID, gameTitle = add_new_game_from_dolphin(path_to_new_game[0])
+            except Exception as e:
+                print("No file selected. Please select a game.")
+                gameID = None
+                gameTitle = None
 
             if gameID is None and gameTitle is None:
                 return

--- a/mainwindowui.py
+++ b/mainwindowui.py
@@ -283,14 +283,14 @@ class MainWindow(QMainWindow):
     def set_directory(self):
         sent_button = self.sender()
         if sent_button == self.modsDirToolbutton:
-            path_to_directory = QFileDialog.getExistingDirectory(self, caption="Select Mod Directory", directory="~", options=QFileDialog.Option.ShowDirsOnly)
+            path_to_directory = QFileDialog.getExistingDirectory(self, caption="Select Mod Directory", options=QFileDialog.Option.ShowDirsOnly)
             plaintext = set_up_directory(path_to_directory, 'modsdir')
             self.modsDirPathField.setPlainText(plaintext)
         elif sent_button == self.dolphinDirToolbutton:
-            path_to_directory = QFileDialog.getExistingDirectory(self, caption="Select Dolphin Directory", directory="~", options=QFileDialog.Option.ShowDirsOnly)
+            path_to_directory = QFileDialog.getExistingDirectory(self, caption="Select Dolphin Directory", options=QFileDialog.Option.ShowDirsOnly)
             self.dolphinDirPathField.setPlainText(set_up_directory(path_to_directory, 'dolphindir'))
         elif sent_button == self.texturesDirToolbutton:
-            path_to_directory = QFileDialog.getExistingDirectory(self, caption="Select Textures Directory", directory="~", options=QFileDialog.Option.ShowDirsOnly)
+            path_to_directory = QFileDialog.getExistingDirectory(self, caption="Select Textures Directory", options=QFileDialog.Option.ShowDirsOnly)
             self.texturesDirPathField.setPlainText(set_up_directory(path_to_directory, 'texturesdir'))
         pass
 
@@ -299,7 +299,7 @@ class MainWindow(QMainWindow):
     def game_combo_box_option_select(self):
         selected_item = self.currentGameCombobox.currentText()
         if selected_item == "Add new game here":
-            path_to_new_game = QFileDialog.getOpenFileName(self, caption="Select Game", directory="~", filter="Games (*.iso)")
+            path_to_new_game = QFileDialog.getOpenFileName(self, caption="Select Game", filter="Games (*.iso)")
             gameID, gameTitle = add_new_game_from_dolphin(path_to_new_game[0])
 
             if gameID is None and gameTitle is None:

--- a/mainwindowui.py
+++ b/mainwindowui.py
@@ -252,16 +252,30 @@ class MainWindow(QMainWindow):
     def open_directory(self):
         sent_button = self.sender()
         if sent_button == self.openModsPushbutton:
-            os.startfile(get_config_option(SETTINGS_INI,
-                                           "config",
-                                           "LauncherLoader",
-                                           "modsdir"))
+            if sys.platform == "win32":
+                os.startfile(get_config_option(SETTINGS_INI,
+                                            "config",
+                                            "LauncherLoader",
+                                            "modsdir"))
+            else:
+                opener = "open" if sys.platform == "darwin" else "xdg-open"
+                subprocess.call([opener, get_config_option(SETTINGS_INI,
+                                            "config",
+                                            "LauncherLoader",
+                                            "modsdir")])
 
         if sent_button == self.openDolphinPushbutton:
-            os.startfile(get_config_option(SETTINGS_INI,
-                                           "config",
-                                           "LauncherLoader",
-                                           "dolphindir"))
+            if sys.platform == "win32":
+                os.startfile(get_config_option(SETTINGS_INI,
+                                            "config",
+                                            "LauncherLoader",
+                                            "dolphindir"))
+            else:
+                opener = "open" if sys.platform == "darwin" else "xdg-open"
+                subprocess.call([opener, get_config_option(SETTINGS_INI,
+                                            "config",
+                                            "LauncherLoader",
+                                            "dolphindir")])
         pass
 
 
@@ -271,7 +285,9 @@ class MainWindow(QMainWindow):
         if sent_button == self.modsDirToolbutton:
             print("We are about to set up modsdir.\n") # Currently crashing right after this on macOS.
             print(f"modsDirPathField is {self.modsDirPathField}")
-            self.modsDirPathField.setPlainText(set_up_directory('modsdir'))
+            plaintext = set_up_directory('modsdir')
+            print("See if we got here.")
+            self.modsDirPathField.setPlainText(plaintext)
         elif sent_button == self.dolphinDirToolbutton:
             self.dolphinDirPathField.setPlainText(set_up_directory('dolphindir'))
         elif sent_button == self.texturesDirToolbutton:

--- a/mainwindowui.py
+++ b/mainwindowui.py
@@ -55,8 +55,12 @@ class MainWindow(QMainWindow):
         # This does technically start a thread, but you can never update the thread... which sucks
         client_id = "1432755181598150908"
         # Init thread in window to access later?
-        RPC_Thread = threading.Thread(name="discord-RPC", target=richpresence.RPC_loop(client_id), daemon=True)
-        RPC_Thread.start()
+        try:
+            RPC_Thread = threading.Thread(name="discord-RPC", target=richpresence.RPC_loop(client_id), daemon=True)
+            RPC_Thread.start()
+        except Exception as e:
+            print("Discord not found. Skipping rich presence...")
+
 
         # ATTACH ALL BUTTON BEHAVIOR IN HERE
 
@@ -265,6 +269,8 @@ class MainWindow(QMainWindow):
     def set_directory(self):
         sent_button = self.sender()
         if sent_button == self.modsDirToolbutton:
+            print("We are about to set up modsdir.\n") # Currently crashing right after this on macOS.
+            print(f"modsDirPathField is {self.modsDirPathField}")
             self.modsDirPathField.setPlainText(set_up_directory('modsdir'))
         elif sent_button == self.dolphinDirToolbutton:
             self.dolphinDirPathField.setPlainText(set_up_directory('dolphindir'))

--- a/mainwindowui.py
+++ b/mainwindowui.py
@@ -10,7 +10,7 @@ from constants import * # Contains our paths
 from PyQt6 import QtCore, QtGui, QtWidgets, uic
 from PyQt6.QtCore import QRunnable, pyqtSlot, QThreadPool
 from PyQt6.QtWidgets import QApplication, QMainWindow, QPushButton, QLabel, QComboBox, QVBoxLayout, QWidget, QLineEdit, \
-    QDialog
+    QFileDialog
 
 from reordermodsui import ReorderModsWindow
 from addmodui import AddModWindow
@@ -283,15 +283,15 @@ class MainWindow(QMainWindow):
     def set_directory(self):
         sent_button = self.sender()
         if sent_button == self.modsDirToolbutton:
-            print("We are about to set up modsdir.\n") # Currently crashing right after this on macOS.
-            print(f"modsDirPathField is {self.modsDirPathField}")
-            plaintext = set_up_directory('modsdir')
-            print("See if we got here.")
+            path_to_directory = QFileDialog.getExistingDirectory(self, caption="Select Mod Directory", directory="~", options=QFileDialog.Option.ShowDirsOnly)
+            plaintext = set_up_directory(path_to_directory, 'modsdir')
             self.modsDirPathField.setPlainText(plaintext)
         elif sent_button == self.dolphinDirToolbutton:
-            self.dolphinDirPathField.setPlainText(set_up_directory('dolphindir'))
+            path_to_directory = QFileDialog.getExistingDirectory(self, caption="Select Dolphin Directory", directory="~", options=QFileDialog.Option.ShowDirsOnly)
+            self.dolphinDirPathField.setPlainText(set_up_directory(path_to_directory, 'dolphindir'))
         elif sent_button == self.texturesDirToolbutton:
-            self.texturesDirPathField.setPlainText(set_up_directory('texturesdir'))
+            path_to_directory = QFileDialog.getExistingDirectory(self, caption="Select Textures Directory", directory="~", options=QFileDialog.Option.ShowDirsOnly)
+            self.texturesDirPathField.setPlainText(set_up_directory(path_to_directory, 'texturesdir'))
         pass
 
 
@@ -299,7 +299,8 @@ class MainWindow(QMainWindow):
     def game_combo_box_option_select(self):
         selected_item = self.currentGameCombobox.currentText()
         if selected_item == "Add new game here":
-            gameID, gameTitle = add_new_game_from_dolphin()
+            path_to_new_game = QFileDialog.getOpenFileName(self, caption="Select Game", directory="~", filter="Games (*.iso)")
+            gameID, gameTitle = add_new_game_from_dolphin(path_to_new_game[0])
 
             if gameID is None and gameTitle is None:
                 return

--- a/modfileutils.py
+++ b/modfileutils.py
@@ -8,7 +8,7 @@ import shutil
 import hashlib
 import uuid
 import tkinter
-from tkinter import filedialog
+# from tkinter import filedialog
 from constants import DOLPHIN_TOOL, SETTINGS_INI, MODSDB_INI, MOD_PACK_DIR, ORIGINAL_ISO_DIR, MOD_ISO_DIR
 from filemanagerutils import get_config_option, set_config_option
 

--- a/modfileutils.py
+++ b/modfileutils.py
@@ -350,7 +350,12 @@ def create_mod_dirs(new_mod_data, path_to_add):
             files_path = os.path.join(path_to_add, Path("files"))
             os.mkdir(files_path)
         if new_mod_data["Open Folder"]:
-            os.startfile(path_to_add)
+            if sys.platform == "win32":
+                os.startfile(path_to_add)
+            else:
+                opener = "open" if sys.platform == "darwin" else "xdg-open"
+                subprocess.call([opener, path_to_add])
+            
 
     except FileExistsError:
         print("Mod already exists!")

--- a/windowUIFiles/mainwindow.ui
+++ b/windowUIFiles/mainwindow.ui
@@ -96,9 +96,9 @@
                 </widget>
                </item>
                <item>
-                <widget class="QPushButton" name="configModButton">
+                <widget class="QPushButton" name="compileModsButton">
                  <property name="text">
-                  <string>Configure Mod</string>
+                  <string>Compile Mods</string>
                  </property>
                 </widget>
                </item>
@@ -374,14 +374,14 @@
             <widget class="QWidget" name="widget_7" native="true">
              <layout class="QHBoxLayout" name="horizontalLayout_7">
               <item>
-               <widget class="QLabel" name="texturesDirLabel">
+               <widget class="QLabel" name="pluginsDirLabel">
                 <property name="text">
-                 <string>Textures Directory:</string>
+                 <string>Plugins Directory:</string>
                 </property>
                </widget>
               </item>
               <item>
-               <widget class="QPlainTextEdit" name="texturesDirPathField">
+               <widget class="QPlainTextEdit" name="pluginsDirPathField">
                 <property name="maximumSize">
                  <size>
                   <width>16777215</width>
@@ -400,7 +400,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QToolButton" name="texturesDirToolbutton">
+               <widget class="QToolButton" name="pluginsDirToolbutton">
                 <property name="text">
                  <string>...</string>
                 </property>


### PR DESCRIPTION
Pushing the stable Mac version first, Linux is going to need a good handful more in terms of workarounds.

Main changes:

- Added constants for dolphin and dolphin-tools on MacOS, left placeholder for Linux
- Added non-Windows subprocess calls
- Removed/commented out all calls to tkinter, replaced filedialog with QFileDialog from PyQt6